### PR TITLE
Enforce unique shift request per user and project

### DIFF
--- a/app/models/shift_request.rb
+++ b/app/models/shift_request.rb
@@ -1,4 +1,6 @@
 class ShiftRequest < ApplicationRecord
   belongs_to :user
   belongs_to :project
+
+  validates :project_id, uniqueness: { scope: :user_id }
 end

--- a/db/migrate/20250514130000_add_unique_index_to_shift_requests.rb
+++ b/db/migrate/20250514130000_add_unique_index_to_shift_requests.rb
@@ -1,0 +1,6 @@
+class AddUniqueIndexToShiftRequests < ActiveRecord::Migration[7.1]
+  def change
+    add_index :shift_requests, [:user_id, :project_id], unique: true
+  end
+end
+

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_05_14_005604) do
+ActiveRecord::Schema[7.1].define(version: 2025_05_14_130000) do
   create_table "projects", force: :cascade do |t|
     t.string "title"
     t.date "work_date"
@@ -39,6 +39,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_05_14_005604) do
     t.datetime "updated_at", null: false
     t.index ["project_id"], name: "index_shift_requests_on_project_id"
     t.index ["user_id"], name: "index_shift_requests_on_user_id"
+    t.index ["user_id", "project_id"], name: "index_shift_requests_on_user_id_and_project_id", unique: true
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
## Summary
- validate shift requests so each user can request a project only once
- add unique DB index on `[user_id, project_id]`

## Testing
- `ruby bin/rails test` *(fails: Your Ruby version is 3.4.4, but your Gemfile specified 3.3.8)*

------
https://chatgpt.com/codex/tasks/task_e_68bfe7bb9d388327aad94d67fcf3120f