### PR TITLE
Use strong params for shift requests

### DIFF
--- a/app/controllers/scheduler/shift_requests_controller.rb
+++ b/app/controllers/scheduler/shift_requests_controller.rb
@@ -56,8 +56,8 @@ class Scheduler::ShiftRequestsController < ApplicationController
 
   # -- シフト希望送信-------------------------------------------------
   def create
-    shift_request = current_user.shift_requests.find_or_initialize_by(project_id: params[:project_id])
-    shift_request.status = params[:status]
+    shift_request_params = params.require(:shift_request).permit(:project_id, :status)
+    shift_request = current_user.shift_requests.find_or_initialize_by(shift_request_params)
 
     if shift_request.save
       redirect_to scheduler_shift_requests_path, notice: "希望を送信しました"


### PR DESCRIPTION
## Summary
- handle shift requests through strong params

## Testing
- `bundle exec rails test` *(fails: bundler: command not found: rails)*
- `bundle install` *(fails: Ruby version 3.4.4 but Gemfile specifies 3.3.8)*

------
https://chatgpt.com/codex/tasks/task_e_68bfe7f4aad8832799624de288007b21