### PR TITLE
Implement manager project assignment confirmation

### DIFF
--- a/app/controllers/manager/projects_controller.rb
+++ b/app/controllers/manager/projects_controller.rb
@@ -40,6 +40,21 @@ class Manager::ProjectsController < Manager::BaseController
   end
 
   # ────────────────────────────────────
+  # PATCH /manager/projects/:id/complete_assignment
+  # 指定ユーザーを確定する
+  def complete_assignment
+    @project = Project.find(params[:id])
+    user_id  = params.require(:user_id).to_i
+
+    # 既存の希望・確定レコードを削除してから確定を作成
+    @project.shift_requests.where(user_id: user_id).destroy_all
+    @project.shift_assignments.where(user_id: user_id).destroy_all
+    @project.shift_assignments.create!(user_id: user_id)
+
+    redirect_to assignment_manager_project_path(@project), notice: "スタッフを確定しました"
+  end
+
+  # ────────────────────────────────────
   # PATCH /manager/projects/:id/toggle_request
   # 確定⇔希望 を切り替える Ajax/HTML ハンドラ
   def toggle_request

--- a/app/views/manager/projects/assignment.html.erb
+++ b/app/views/manager/projects/assignment.html.erb
@@ -68,12 +68,10 @@
       </div>
       <div class="panel__body assignment-list">
         <% @shift_requests.each do |req| %>
-          <button type="button"
-                  class="chip level-<%= req.user.skill_level %>"
-                  data-action="click->toggle-user#toggle"
-                  data-toggle-user-user-id-value="<%= req.user.id %>">
-            <%= req.user.name %>
-          </button>
+          <%= link_to req.user.name,
+                      complete_assignment_manager_project_path(@project, user_id: req.user.id),
+                      data: { turbo_method: :patch },
+                      class: "chip level-#{req.user.skill_level}" %>
         <% end %>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add `complete_assignment` action to confirm a user on a project
- link shift request entries to call the new action

## Testing
- `bundle exec rails test` *(fails: command not found: rails / Ruby version mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68bfe7ddfc748327821d9d8542384030