### PR TITLE
Add project date scope and assignment update helper

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -7,6 +7,9 @@ class Project < ApplicationRecord
   # work_dateを必須にする
   validates :work_date, presence: true
 
+  # 指定期間内のProjectを取得
+  scope :within, ->(start_date, end_date) { where(work_date: start_date..end_date) }
+
   # 必要人数に達するまで希望者を確定者に変換する例
   def complete_shift_assignments!
     needed = required_number - shift_assignments.count
@@ -19,6 +22,18 @@ class Project < ApplicationRecord
 
     # （任意）既に割り当て済みの shift_requests は削除しておく
     shift_requests.where(id: shift_assignments.pluck(:id)).destroy_all
+  end
+
+  # 与えられたユーザーIDに合わせてシフト割当を再構築する
+  def update_assignments(user_ids)
+    user_ids = Array(user_ids).map(&:to_i).uniq
+
+    shift_assignments.where.not(user_id: user_ids).destroy_all
+
+    existing_ids = shift_assignments.pluck(:user_id)
+    (user_ids - existing_ids).each do |uid|
+      shift_assignments.create!(user_id: uid)
+    end
   end
 
 end

--- a/test/fixtures/projects.yml
+++ b/test/fixtures/projects.yml
@@ -3,9 +3,9 @@
 one:
   title: MyString
   work_date: 2025-05-03
-  required_workers: 1
+  required_number: 1
 
 two:
   title: MyString
   work_date: 2025-05-03
-  required_workers: 1
+  required_number: 1

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -1,7 +1,26 @@
 require "test_helper"
 
 class ProjectTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "within returns projects in range" do
+    p1 = projects(:one)
+    p2 = projects(:two)
+    p3 = Project.create!(title: "Outside", work_date: Date.new(2025, 6, 1))
+
+    results = Project.within(Date.new(2025, 5, 1), Date.new(2025, 5, 31))
+    assert_includes results, p1
+    assert_includes results, p2
+    assert_not_includes results, p3
+  end
+
+  test "update_assignments rebuilds assignments based on user_ids" do
+    project = projects(:one)
+    user1 = users(:one)
+    user2 = users(:two)
+
+    assert_equal [user1.id], project.shift_assignments.pluck(:user_id)
+
+    project.update_assignments([user2.id])
+
+    assert_equal [user2.id], project.shift_assignments.pluck(:user_id)
+  end
 end


### PR DESCRIPTION
## Summary
- add `within` scope to filter projects by `work_date` range
- rebuild shift assignments based on provided user IDs via `update_assignments`
- fix project fixtures and add tests for new behavior

## Testing
- `bundle exec rails test` *(fails: bundler: command not found: rails)*
- `ruby bin/rails test` *(fails: Your Ruby version is 3.4.4, but your Gemfile specified 3.3.8)*

------
https://chatgpt.com/codex/tasks/task_e_68bfe7dbdf608327885b12924ba0a1e3