### PR TITLE
Migrate skill level to integer

### DIFF
--- a/app/controllers/manager/users_controller.rb
+++ b/app/controllers/manager/users_controller.rb
@@ -21,7 +21,7 @@ class Manager::UsersController < ApplicationController
     @user = User.new(user_params.merge(
       password:              random_pw,
       password_confirmation: random_pw,
-      skill_level: 0
+      skill_level:           user_params[:skill_level].to_i
     ))
 
     if @user.save

--- a/db/migrate/20250515000000_change_skill_level_to_integer_in_users.rb
+++ b/db/migrate/20250515000000_change_skill_level_to_integer_in_users.rb
@@ -1,0 +1,9 @@
+class ChangeSkillLevelToIntegerInUsers < ActiveRecord::Migration[7.1]
+  def up
+    change_column :users, :skill_level, :integer, using: 'skill_level::integer', default: 0
+  end
+
+  def down
+    change_column :users, :skill_level, :string, default: nil
+  end
+end


### PR DESCRIPTION
## Summary
- convert users.skill_level column from string to integer
- ensure manager users controller casts skill level input to an integer

## Testing
- `bundle exec rails db:migrate` *(fails: command not found: rails)*
- `bundle exec rails test` *(fails: command not found: rails)*

------
https://chatgpt.com/codex/tasks/task_e_68bfe7f43f1483279662a4039368c3bf