### PR TITLE
Load Turbo via importmap

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,2 +1,2 @@
-import "./turbo.min.js"
+import "@hotwired/turbo-rails"
 import "./controllers"


### PR DESCRIPTION
## Summary
- use `@hotwired/turbo-rails` via Importmap instead of missing local file

## Testing
- `ruby bin/importmap pin @hotwired/turbo-rails @hotwired/stimulus @hotwired/stimulus-loading` *(fails: Your Ruby version is 3.4.4, but your Gemfile specified 3.4.5)*
- `ruby bin/rails assets:precompile` *(fails: Your Ruby version is 3.4.4, but your Gemfile specified 3.4.5)*

------
https://chatgpt.com/codex/tasks/task_e_68c4da3270e88327a8e6c5da85efa544