### PR TITLE
refactor: align scheduler CSS variables with base palette

### DIFF
--- a/app/assets/stylesheets/scheduler/style.css
+++ b/app/assets/stylesheets/scheduler/style.css
@@ -1,5 +1,5 @@
 .scheduler-container {
-  background-color: var(--secondary1--color);
+  background-color: var(--color-secondary-1);
   user-select: none;
 }
 .scheduler-wrapper {
@@ -23,7 +23,7 @@
   height: 60px;line-height: 60px;
   font-size: 16px;
   font-weight: 600;
-  color: var(--secondary6--color);
+  color: var(--color-secondary-6);
   z-index: 1;
 }
 .tab-nav {
@@ -37,13 +37,13 @@
 .tab-nav .nav-item {
   flex: 1;
   font-weight: bold;
-  color: var(--secondary5--color);
+  color: var(--color-secondary-5);
   font-size: 12px;
 }
 
 .tab-nav .nav-item.active {
-  color: var(--primary7-color);
-  border-bottom: solid 3px var(--primary7-color);;
+  color: var(--color-primary-7);
+  border-bottom: solid 3px var(--color-primary-7);
 }
 
 
@@ -95,7 +95,7 @@
 
 .calendar-caption {
   margin-bottom:20px;
-  color: var(--secondary6--color);
+  color: var(--color-secondary-6);
 }
 
 .weekday {
@@ -108,7 +108,7 @@
 .day-box {
   width: 45px;
   height: 45px;
-  border: solid 1px var(--secondary2--color);
+  border: solid 1px var(--color-secondary-2);
   cursor: pointer;
   position: relative;
   text-align: center;
@@ -121,7 +121,7 @@
 p.today {
   margin: 0 auto;
   width: 20px;
-  background-color: var(--primary7-color);
+  background-color: var(--color-primary-7);
   border-radius: 50%;
   color: #FFF;
   font-weight: 700;
@@ -136,7 +136,7 @@ p.today {
   width: 10px;
   height: 10px;
   border-radius: 50%;
-  background-color:var(--accent-red5-color);
+  background-color: var(--color-accent-red-5);
   position: absolute;
   top: 70%;
   left: 50%;
@@ -164,7 +164,7 @@ body:has(.modal.open) .swiper-slide {
 /* 手伝ってください！ */
 .bubble {
   display: inline-block;
-  background: var(--secondary1--color);
+  background: var(--color-secondary-1);
   width: 100%;
   height: 80px;
   border-radius: 12px;
@@ -175,7 +175,7 @@ body:has(.modal.open) .swiper-slide {
 
 .remaining-count {
   padding: 0 3px;
-  color: var(--primary5-color);
+  color: var(--color-primary-5);
   font-size: 20px;
   font-weight: bold;
 }
@@ -203,12 +203,12 @@ body:has(.modal.open) .swiper-slide {
   font-size: 0.9rem;
 }
 .btn--ng {
-  background-color: var(--secondary5--color);
+  background-color: var(--color-secondary-5);
   box-shadow: 0px 2px 0px 0px rgba(0, 0, 0, 0.15);
   line-height: 50px;
 }
 .btn--ok {
-  background-color: var(--primary5-color);
+  background-color: var(--color-primary-5);
   box-shadow: 0px 2px 0px 0px rgba(0, 0, 0, 0.15);
   color: #FFF;
   line-height: 50px;


### PR DESCRIPTION
## Summary
- use `base/main.css` color variable names in scheduler styles
- remove stray semicolon and ensure file ends with newline

## Testing
- `bundle exec rake test` *(fails: Your Ruby version is 3.4.4, but your Gemfile specified 3.4.5)*

------
https://chatgpt.com/codex/tasks/task_e_68c4de8b24a08327b2498943e43c79b4