### PR TITLE
Add Swiper CSS to scheduler layout

### DIFF
--- a/app/views/layouts/scheduler.html.erb
+++ b/app/views/layouts/scheduler.html.erb
@@ -11,6 +11,9 @@
     <%= stylesheet_link_tag "scheduler/base", "data-turbo-track": "reload" %>
 
     <%= javascript_importmap_tags %>
+
+    <!-- Swiper CSS -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.css" />
   </head>
 
   <body>


### PR DESCRIPTION
## Summary
- add Swiper CSS link to scheduler layout

## Testing
- `bundle exec rails test` (fails: bundler: command not found: rails)
- `bundle install` (Ruby version 3.4.4, Gemfile requires 3.4.5)


------
https://chatgpt.com/codex/tasks/task_e_68c4dea229f883278694d9f89ca0548f