### PR TITLE
Use staff shift request modal path in Stimulus controller

### DIFF
--- a/app/javascript/controllers/modal_controller.js
+++ b/app/javascript/controllers/modal_controller.js
@@ -12,7 +12,7 @@ export default class extends Controller {
     }
     // ——————————————
 
-    fetch(`/scheduler/shift_requests/modal?project_ids=${ids}`)
+    fetch(`/staff/shift_requests/modal?project_ids=${ids}`)
       .then(res => res.text())
       .then(html => {
         this.bodyTarget.innerHTML = html


### PR DESCRIPTION
## Summary
- update modal controller to fetch from staff shift requests path

## Testing
- ⚠️ `bundle exec rails test` *(could not run: bundler: command not found: rails; attempting `bundle install` failed: Your Ruby version is 3.4.4, but your Gemfile specified 3.4.5)*

------
https://chatgpt.com/codex/tasks/task_e_68c4e23105c083279a1588fe5b67dbfe