### PR TITLE
Move shift requests controller to staff namespace

### DIFF
--- a/app/controllers/staff/shift_requests_controller.rb
+++ b/app/controllers/staff/shift_requests_controller.rb
@@ -1,5 +1,5 @@
-# app/controllers/scheduler/shift_requests_controller.rb
-class Scheduler::ShiftRequestsController < ApplicationController
+# app/controllers/staff/shift_requests_controller.rb
+class Staff::ShiftRequestsController < ApplicationController
   layout 'scheduler'
   before_action :authenticate_user!
 
@@ -62,11 +62,11 @@ class Scheduler::ShiftRequestsController < ApplicationController
     sr.assign_attributes(status: attrs[:status])
 
     sr.save!
-    redirect_to scheduler_shift_requests_path, notice: "希望を送信しました"
+    redirect_to staff_shift_requests_path, notice: "希望を送信しました"
   rescue ActiveRecord::RecordNotUnique
-    redirect_to scheduler_shift_requests_path, notice: "既に希望を受け付けています"
+    redirect_to staff_shift_requests_path, notice: "既に希望を受け付けています"
   rescue ActiveRecord::RecordInvalid
-    redirect_to scheduler_shift_requests_path, alert: sr.errors.full_messages.to_sentence
+    redirect_to staff_shift_requests_path, alert: sr.errors.full_messages.to_sentence
   end
 
 end

--- a/app/views/staff/calendar/_modal_body.html.erb
+++ b/app/views/staff/calendar/_modal_body.html.erb
@@ -26,7 +26,7 @@
   
   <!-- OK／NG ボタン -->
   <div class="form-shift">
-    <%= form_with url: scheduler_shift_requests_path, method: :post, local: true do |f| %>
+    <%= form_with url: staff_shift_requests_path, method: :post, local: true do |f| %>
       <p class="actions-title">あなたのシフト希望</p>
       <%= f.hidden_field :project_id, value: project.id %>
       <div class="actions-buttons">

--- a/app/views/staff/myshifts/_shift_preferences.html.erb
+++ b/app/views/staff/myshifts/_shift_preferences.html.erb
@@ -15,7 +15,7 @@
         <td><%= project.title %></td>
         <td>
           <% current_status = @shift_requests[project.id]&.status %>
-          <%= form_with url: scheduler_shift_requests_path,
+          <%= form_with url: staff_shift_requests_path,
                         method: :post,
                         local: true,
                         class: "preference-form" do |f| %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
   # root は devise_scope で囲む
   devise_scope :user do
     authenticated :user do
-      root "scheduler/shift_requests#index", as: :authenticated_root
+      root "staff/shift_requests#index", as: :authenticated_root
     end
 
     unauthenticated do
@@ -14,7 +14,7 @@ Rails.application.routes.draw do
   end
 
   # スタッフ画面（Shift Scheduler）
-  namespace :scheduler do
+  namespace :staff do
     resources :shift_requests, only: [:index, :create] do
       collection do
         get :modal, :my_shifts


### PR DESCRIPTION
## Summary
- move shift request controller under staff namespace
- update routes and helpers to use staff paths

## Testing
- `bundle exec rake test` *(fails: Your Ruby version is 3.4.4, but your Gemfile specified 3.4.5)*

------
https://chatgpt.com/codex/tasks/task_e_68c506f97ccc83278db6cfa73db0210a