### PR TITLE
feat(calendar): highlight entire cell for today

### DIFF
--- a/app/assets/stylesheets/staff/style.css
+++ b/app/assets/stylesheets/staff/style.css
@@ -117,22 +117,36 @@
 }
 .day-box p {
   margin-bottom: 3px;
-  height: 20px;line-height: 20px;
-  
+  height: 20px;
+  line-height: 20px;
   font-size: 12px;
 }
-p.today {
-  margin: 0 auto;
-  width: 20px;
-  background-color: var(--color-primary-7);
-  border-radius: 50%;
-  color: #FFF;
-  font-weight: 700;
+
+/* The whole cell becomes highlighted for today */
+.day-box.today {
+  background: #f5faff;
+  border-radius: 10px;
+  box-shadow: 0 0 0 1px rgba(59,130,246,0.15) inset;
 }
 
-.not-current {
-  color: #ccc;
-  opacity: 0.6;
+/* keep number readable and slightly stronger on today */
+.day-box.today .day-number {
+  font-weight: 600;
+  color: #1e3a8a;
+}
+
+/* out-of-month dates look muted */
+.day-box.not-current .day-number {
+  opacity: 0.4;
+}
+
+/* optional: hover affordance */
+.calendar-cell .day-box {
+  transition: background 0.15s ease, box-shadow 0.15s ease, transform 0.02s;
+}
+
+.calendar-cell .day-box:hover {
+  background: #f8fbff;
 }
 
 .more-needed {

--- a/app/views/staff/calendar/_calendar_view.html.erb
+++ b/app/views/staff/calendar/_calendar_view.html.erb
@@ -19,21 +19,19 @@
           <% week.each do |day| %>
             <% if day.present? %>
               <% projects = @projects_by_date[day] || [] %>
-              <td>
+              <td class="calendar-cell">
                 <div
-                  class="day-box"
+                  class="<%= ['day-box',
+                              ('today' if day == Date.current),
+                              ('not-current' if day.month != base_date.month)
+                             ].compact.join(' ') %>"
                   data-action="click->modal#open"
                   data-date="<%= day %>"
                   <% if projects.any? %>
                     data-project-ids="<%= projects.map(&:id).join(',') %>"
                   <% end %>>
-                  
-                  <p class="
-                    <%= 'today'       if day == Date.today %>
-                    <%= 'not-current' if day.month != base_date.month %>
-                  ">
-                    <%= day.day %>
-                  </p>
+
+                  <p class="day-number"><%= day.day %></p>
 
                   <% if projects.any? %>
                     <div class="more-needed"></div>


### PR DESCRIPTION
## Summary
- highlight entire calendar cell for today by moving the `today` class to `.day-box` and using `Date.current`
- add styles so the full `.day-box` is highlighted and muted for out-of-month days

## Testing
- `bundle exec rails test` *(fails: bundler: command not found: rails)*
- `bundle install` *(fails: Ruby 3.4.4 is incompatible with Gemfile's Ruby 3.4.5 requirement)*

------
https://chatgpt.com/codex/tasks/task_e_68c526e1ef38832798157684e62c6364